### PR TITLE
Solved gson UnsafeReflectionAccessor error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.3</version>
+            <version>2.8.6</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Gson version 2.8.3 with JDK 12 have an UnsafeReflectionAccessor error.
![image](https://user-images.githubusercontent.com/43810296/107157782-5bb42980-6986-11eb-9fc2-84041778c4d9.png)
![image](https://user-images.githubusercontent.com/43810296/107157783-5e168380-6986-11eb-82d8-af88e74c2a2e.png)

So, I modified the gson version to a newer version and the problem was solved.
![image](https://user-images.githubusercontent.com/43810296/107157797-6f5f9000-6986-11eb-953f-1c0af49a01e1.png)

